### PR TITLE
Error "End tag 'form' seen, but there were open elements" when using as inline

### DIFF
--- a/Editable.php
+++ b/Editable.php
@@ -487,14 +487,14 @@ HTML;
             echo Html::beginTag('div', $this->inlineSettings['options']);
         }
         echo $this->renderFormFields();
+        if (!$this->asPopover) {
+            echo "</div>\n"; // inline options
+        }
         /**
          * @var ActiveForm $class
          */
         $class = $this->formClass;
         $class::end();
-        if (!$this->asPopover) {
-            echo "</div>\n"; // inline options
-        }
         echo "</div>\n"; // content options
         if ($this->asPopover === true) {
             PopoverX::end();


### PR DESCRIPTION
When using the widget with setting "asPopover" set to false, the opening tag and closing tag doesn't match.
The `<div class="panel panel-default">` inside the form is not properly closed.