### PR TITLE
Exit inline form on escape

### DIFF
--- a/Editable.php
+++ b/Editable.php
@@ -379,6 +379,11 @@ HTML;
      * @var boolean whether to auto submit/save the form on pressing ENTER key. Defaults to `true`.
      */
     public $submitOnEnter = true;
+	
+	/**
+     * @var boolean whether to exit the form on pressing ESC key. Defaults to `true`.
+     */
+    public $closeOnEscape = true;
 
     /**
      * @var boolean whether to HTML encode the output via javascript after editable update. Defaults to `true`. Note that
@@ -523,6 +528,7 @@ HTML;
             'showAjaxErrors' => $this->showAjaxErrors,
             'ajaxSettings' => $this->ajaxSettings,
             'submitOnEnter' => $this->submitOnEnter,
+			'closeOnEscape' => $this->closeOnEscape,
             'encodeOutput' => $this->encodeOutput,
         ];
         $this->registerPlugin('editable', 'jQuery("#' . $this->containerOptions['id'] . '")');
@@ -650,7 +656,7 @@ HTML;
                 'templateBefore' => self::INLINE_BEFORE_1,
                 'templateAfter' => self::INLINE_AFTER_1,
                 'options' => ['class' => 'panel panel-default'],
-                'closeButton' => "<button type='button' class='kv-editable-close close' title='{$title}'>&times;</button>",
+                'closeButton' => "<button class='kv-editable-close close' title='{$title}'>&times;</button>",
             ], $this->inlineSettings
         );
         Html::addCssClass($this->contentOptions, 'kv-editable-inline');

--- a/Editable.php
+++ b/Editable.php
@@ -380,7 +380,7 @@ HTML;
      */
     public $submitOnEnter = true;
 	
-	/**
+    /**
      * @var boolean whether to exit the form on pressing ESC key. Defaults to `true`.
      */
     public $closeOnEscape = true;
@@ -528,7 +528,7 @@ HTML;
             'showAjaxErrors' => $this->showAjaxErrors,
             'ajaxSettings' => $this->ajaxSettings,
             'submitOnEnter' => $this->submitOnEnter,
-			'closeOnEscape' => $this->closeOnEscape,
+            'closeOnEscape' => $this->closeOnEscape,
             'encodeOutput' => $this->encodeOutput,
         ];
         $this->registerPlugin('editable', 'jQuery("#' . $this->containerOptions['id'] . '")');

--- a/Editable.php
+++ b/Editable.php
@@ -650,7 +650,7 @@ HTML;
                 'templateBefore' => self::INLINE_BEFORE_1,
                 'templateAfter' => self::INLINE_AFTER_1,
                 'options' => ['class' => 'panel panel-default'],
-                'closeButton' => "<button class='kv-editable-close close' title='{$title}'>&times;</button>",
+                'closeButton' => "<button type='button' class='kv-editable-close close' title='{$title}'>&times;</button>",
             ], $this->inlineSettings
         );
         Html::addCssClass($this->contentOptions, 'kv-editable-inline');

--- a/Editable.php
+++ b/Editable.php
@@ -379,11 +379,6 @@ HTML;
      * @var boolean whether to auto submit/save the form on pressing ENTER key. Defaults to `true`.
      */
     public $submitOnEnter = true;
-	
-    /**
-     * @var boolean whether to exit the form on pressing ESC key. Defaults to `true`.
-     */
-    public $closeOnEscape = true;
 
     /**
      * @var boolean whether to HTML encode the output via javascript after editable update. Defaults to `true`. Note that
@@ -528,7 +523,6 @@ HTML;
             'showAjaxErrors' => $this->showAjaxErrors,
             'ajaxSettings' => $this->ajaxSettings,
             'submitOnEnter' => $this->submitOnEnter,
-            'closeOnEscape' => $this->closeOnEscape,
             'encodeOutput' => $this->encodeOutput,
         ];
         $this->registerPlugin('editable', 'jQuery("#' . $this->containerOptions['id'] . '")');

--- a/assets/js/editable.js
+++ b/assets/js/editable.js
@@ -151,8 +151,9 @@
                     }
                     self.refreshPopover();
                 }, 200);
-            }).on('keyup.editable', function (ev) {
-                if (ev.which === 27 && self.closeOnEscape) {
+            });
+            $inline.on('keyup.editable', function (ev) {
+                if (ev.which === 27) {
                     self.raise($close, 'click.editable');
                 }
             });
@@ -321,7 +322,6 @@
         ajaxSettings: {},
         showAjaxErrors: true,
         submitOnEnter: true,
-        closeOnEscape: true,
         asPopover: true,
         encodeOutput: true,
         validationDelay: 500

--- a/assets/js/editable.js
+++ b/assets/js/editable.js
@@ -151,7 +151,11 @@
                     }
                     self.refreshPopover();
                 }, 200);
-            });
+            }).on('keyup.editable', function (ev) {
+				if (ev.which === 27 && self.closeOnEscape) {
+					self.raise($close, 'click.editable');
+				}
+			});
             $form.find('input, select').on('change.editable', function () {
                 if (self.raise($el, 'editableChange', [$input.val()])) {
                     self.refreshPopover();
@@ -317,6 +321,7 @@
         ajaxSettings: {},
         showAjaxErrors: true,
         submitOnEnter: true,
+		closeOnEscape: true,
         asPopover: true,
         encodeOutput: true,
         validationDelay: 500

--- a/assets/js/editable.js
+++ b/assets/js/editable.js
@@ -152,10 +152,10 @@
                     self.refreshPopover();
                 }, 200);
             }).on('keyup.editable', function (ev) {
-				if (ev.which === 27 && self.closeOnEscape) {
-					self.raise($close, 'click.editable');
-				}
-			});
+                if (ev.which === 27 && self.closeOnEscape) {
+                    self.raise($close, 'click.editable');
+                }
+            });
             $form.find('input, select').on('change.editable', function () {
                 if (self.raise($el, 'editableChange', [$input.val()])) {
                     self.refreshPopover();
@@ -321,7 +321,7 @@
         ajaxSettings: {},
         showAjaxErrors: true,
         submitOnEnter: true,
-		closeOnEscape: true,
+        closeOnEscape: true,
         asPopover: true,
         encodeOutput: true,
         validationDelay: 500


### PR DESCRIPTION
## Scope
This pull request includes a

- [ ] New feature

## Changes
The following changes were made

- Popup could be exited pressing ESC key, also made it possible for the inline form.

## Further information
I missed the option of closing the inline form with the ESC key. It triggers a click event for the close button.