### PR TITLE
Fix disappearing form pressing enter.

### DIFF
--- a/Editable.php
+++ b/Editable.php
@@ -379,11 +379,6 @@ HTML;
      * @var boolean whether to auto submit/save the form on pressing ENTER key. Defaults to `true`.
      */
     public $submitOnEnter = true;
-	
-	/**
-     * @var boolean whether to exit the form on pressing ESC key. Defaults to `true`.
-     */
-    public $closeOnEscape = true;
 
     /**
      * @var boolean whether to HTML encode the output via javascript after editable update. Defaults to `true`. Note that
@@ -528,7 +523,6 @@ HTML;
             'showAjaxErrors' => $this->showAjaxErrors,
             'ajaxSettings' => $this->ajaxSettings,
             'submitOnEnter' => $this->submitOnEnter,
-			'closeOnEscape' => $this->closeOnEscape,
             'encodeOutput' => $this->encodeOutput,
         ];
         $this->registerPlugin('editable', 'jQuery("#' . $this->containerOptions['id'] . '")');

--- a/Editable.php
+++ b/Editable.php
@@ -656,7 +656,7 @@ HTML;
                 'templateBefore' => self::INLINE_BEFORE_1,
                 'templateAfter' => self::INLINE_AFTER_1,
                 'options' => ['class' => 'panel panel-default'],
-                'closeButton' => "<button type='button' class='kv-editable-close close' title='{$title}'>&times;</button>",
+                'closeButton' => "<button class='kv-editable-close close' title='{$title}'>&times;</button>",
             ], $this->inlineSettings
         );
         Html::addCssClass($this->contentOptions, 'kv-editable-inline');

--- a/Editable.php
+++ b/Editable.php
@@ -379,6 +379,11 @@ HTML;
      * @var boolean whether to auto submit/save the form on pressing ENTER key. Defaults to `true`.
      */
     public $submitOnEnter = true;
+	
+	/**
+     * @var boolean whether to exit the form on pressing ESC key. Defaults to `true`.
+     */
+    public $closeOnEscape = true;
 
     /**
      * @var boolean whether to HTML encode the output via javascript after editable update. Defaults to `true`. Note that
@@ -523,6 +528,7 @@ HTML;
             'showAjaxErrors' => $this->showAjaxErrors,
             'ajaxSettings' => $this->ajaxSettings,
             'submitOnEnter' => $this->submitOnEnter,
+			'closeOnEscape' => $this->closeOnEscape,
             'encodeOutput' => $this->encodeOutput,
         ];
         $this->registerPlugin('editable', 'jQuery("#' . $this->containerOptions['id'] . '")');

--- a/Editable.php
+++ b/Editable.php
@@ -650,7 +650,7 @@ HTML;
                 'templateBefore' => self::INLINE_BEFORE_1,
                 'templateAfter' => self::INLINE_AFTER_1,
                 'options' => ['class' => 'panel panel-default'],
-                'closeButton' => "<button class='kv-editable-close close' title='{$title}'>&times;</button>",
+                'closeButton' => "<button type='button' class='kv-editable-close close' title='{$title}'>&times;</button>",
             ], $this->inlineSettings
         );
         Html::addCssClass($this->contentOptions, 'kv-editable-inline');


### PR DESCRIPTION
Fix immediately disappearing form in inline mode, when pressing enter.

## Scope
This pull request includes a

- [ ] Bug fix

## Related Issues
https://github.com/kartik-v/yii2-editable/issues/128

## Further information
A form will use the first button it encounters as the submit button, when it doesn't contain a type or is of the type 'submit'. Both the reset and the submit button have the type 'button'. The close button doesn't have a type. When enter is pressed, it will trigger the submit event. Which will trigger the close button. Which will, as coded in JavaScript, close the form.
See also: http://stackoverflow.com/questions/290215/difference-between-input-type-button-and-input-type-submit