### PR TITLE
Fix validation message on kartik/datecontrol/DateControl

### DIFF
--- a/Editable.php
+++ b/Editable.php
@@ -711,6 +711,7 @@ HTML;
                 $options = ArrayHelper::getValue($this->options, 'options.options', []);
                 Html::addCssClass($options, 'kv-editable-input');
                 $this->options['options']['options'] = $options;
+                $this->options['widgetOptions']['options'] = $options;
             } elseif ($this->inputType !== self::INPUT_WIDGET) {
                 $options = ArrayHelper::getValue($this->options, 'options', []);
                 Html::addCssClass($options, 'kv-editable-input');


### PR DESCRIPTION
## Scope
This pull request includes a
- [X] Bug fix

## Changes
The following changes were made:
* Fixed validation error message when using yii2-datecontrol plugin > 1.9.5

## Further Information
https://github.com/kartik-v/yii2-datecontrol included the property widgetOptions in version 1.9.5. In some cases the options for the parsed input widgets are in options['widgetOptions']['options'].