### PR TITLE
Correct html encode

### DIFF
--- a/assets/js/editable.js
+++ b/assets/js/editable.js
@@ -273,6 +273,7 @@
                 $.each(data, function (key, value) {
                     data[key] = self.htmlEncode(value);
                 });
+                return data;
             }
             return data.replace(/&/g, '&amp;')
                 .replace(/</g, '&lt;')


### PR DESCRIPTION
In line 278 'replace' applies to Object, but method object.replace not implemented

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-editable/blob/master/CHANGE.md)):

-
-
-

## Related Issues
If this is related to an existing ticket, include a link to it as well.